### PR TITLE
ADD aur installation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ with an estimated time of completion.
 brew install yxdunc/tools/lipl
 ```
 
+### aur ([arch linux](https://aur.archlinux.org/))
+
+`lipl` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=lipl&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```
+yay -S lipl
+```
+
 ## Arguments
 
 ### positional argument:


### PR DESCRIPTION
Hi,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `lipl` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [lipl](https://aur.archlinux.org/packages/lipl/) (builds from source)
* [lipl-bin](https://aur.archlinux.org/packages/lipl-bin/) (latest binary)
* [lipl-git](https://aur.archlinux.org/packages/lipl-git/) (VCS/development package)

I also updated README.md about installation from AUR. (8113f62)

BR,
orhun.